### PR TITLE
add section to explain how to setup a mongodb server

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,57 @@ Running the following commands will create a Docker image called `mongodb-dumper
 docker build -t mongodb-dumper -f Dockerfile ..
 ```
 
+
+### Setup MongoDB Server
+
+There are different ways how you could setup a mongoDB server. You could either buy a managed mongoDB server (e.g. at [render.com](https://render.com/docs/deploy-mongodb) ), run a mongoDB server directly on your host system or run a mongoDB server inside a separate docker container. The last option is recommended.
+
+Here is a quick guide on how to run a mongoDB server in a separate docker container.
+
+1. First create a new directory:
+```
+mkdir mongodb
+```
+
+Your directory structure should now look as following:
+```
+- mongodb
+- mongodb-dumper
+- core
+```
+
+2. Switch to the newly created `mongodb` directory:
+```
+cd mongodb
+```
+
+3. Create a new docker compose file to specifcy attributes of your mongodb docker container
+
+docker-compose.yml
+```
+version: '3.7'
+services:
+  mongodb_container:
+    image: mongo:latest
+    environment:
+      MONGO_INITDB_ROOT_USERNAME: root
+      MONGO_INITDB_ROOT_PASSWORD: rootpassword
+    ports:
+      - 27017:27017
+    volumes:
+      - mongodb_data_container:/data/db
+
+volumes:
+  mongodb_data_container:
+```
+
+Your mongodb username will be `root` and your password will be `rootpassword`. At this point you should watch out if you expose the port `27017` of your host system to the internet. In case you do expose this port, you should change the username and the password to something else otherwise attackers from outside might delete your data or worse manipulate it without you knowing about it.
+
+4. Run mongodb container
+```
+docker-compose up
+```
+
 ### Run
 
 You may need sudo:
@@ -33,6 +84,6 @@ Configure the connection to mongodb:
 You may need to connect to the localhost network or supply DB authentication:
 
 ```
-docker run --network="host" -it mongodb-dumper /bitclout/bin/mongodb-dumper run --mongo-uri "mongodb://userx:passwd@localhost:27017"
+docker run --network="host" -it mongodb-dumper /bitclout/bin/mongodb-dumper run --mongo-uri "mongodb://root:rootpassword@localhost:27017"
 ```
 


### PR DESCRIPTION
This PR adds a section on how to setup a MongoDB server in a separate docker container. 

Why is it necessary?
Initially, I thought the repo would setup a mongodb for me. This is not the case. When I tried to setup a mongodb server myself I ran into a connection issue. I looked for raised issues in the repo but they didn't solve my problem. In particular, the following closed issue [link] (https://github.com/bitclout/mongodb-dumper/issues/3) was misleading and I wasted a couple of hours. I hope this PR saves people some time.